### PR TITLE
Fix babel config to ignore templates directories

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,4 @@
 {
   "presets": ["es2015", "stage-0"],
-  "plugins": ["add-module-exports"],
-  "ignore": [
-    "app/templates",
-    "model/templates",
-    "controller/templates",
-    "policy/templates",
-    "service/templates"
-  ]
+  "plugins": ["add-module-exports"]
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "generators/app/index.js",
   "scripts": {
     "clean": "rm -rf ./generators",
-    "compile": "npm run clean && cp -r src/ generators/ && babel src --out-dir generators",
+    "compile": "npm run clean && cp -r src/ generators/ && babel src --out-dir generators --ignore **/templates/**",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "dev": "npm run clean && cp -r src/ generators/ && babel src --watch --out-dir generators",
     "prepublish": "npm run compile",


### PR DESCRIPTION
For some reason `ignore` field is ignore under .bablerc. So move it to `package.json` command line.
